### PR TITLE
Rename collection file

### DIFF
--- a/lib/commands/generate_command.dart
+++ b/lib/commands/generate_command.dart
@@ -110,8 +110,8 @@ class GenerateCommand extends Command {
       bool ignoreMissingFiles = false,
       bool verbose = false}) {
     stdout.writeln("Building ${collection.name} collection files...");
-    final listFiles =
-        collection.getFilesList(sharedAssetsPath, collectionsPath, _configuration.version);
+    final listFiles = collection.getFilesList(
+        sharedAssetsPath, collectionsPath, _configuration.version);
     final variants = collection.getListVariant();
 
     // Create missing files text file.

--- a/lib/commands/generate_command.dart
+++ b/lib/commands/generate_command.dart
@@ -19,6 +19,8 @@ class GenerateCommand extends Command {
 
   late Directory _outputDir;
 
+  late Configuration _configuration;
+
   GenerateCommand() {
     argParser
       ..addFlag("ignore-missing-files",
@@ -73,12 +75,12 @@ class GenerateCommand extends Command {
     final configFile = File(argResults!["config"]);
 
     // Load configuration file
-    Configuration configuration =
+    _configuration =
         Configuration.fromYaml(loadYaml(configFile.readAsStringSync()));
     // If verbose
     if (verbose) {
       stdout.writeln(
-          "Configuration file loaded, version: ${configuration.version}");
+          "Configuration file loaded, version: ${_configuration.version}");
     }
 
     _outputDir = Directory(argResults!["output"]);
@@ -89,7 +91,7 @@ class GenerateCommand extends Command {
 
     // Build collections scenes
     stdout.writeln("Processing collections...");
-    for (CollectionConfiguration collection in configuration.collections) {
+    for (CollectionConfiguration collection in _configuration.collections) {
       processCollection(collection,
           sharedAssetsPath: argResults!["shared-dir-path"],
           collectionsPath: argResults!["collections-dir-path"],
@@ -109,7 +111,7 @@ class GenerateCommand extends Command {
       bool verbose = false}) {
     stdout.writeln("Building ${collection.name} collection files...");
     final listFiles =
-        collection.getFilesList(sharedAssetsPath, collectionsPath);
+        collection.getFilesList(sharedAssetsPath, collectionsPath, _configuration.version);
     final variants = collection.getListVariant();
 
     // Create missing files text file.

--- a/lib/commands/verify_command.dart
+++ b/lib/commands/verify_command.dart
@@ -102,7 +102,8 @@ class VerifyCommand extends Command {
     // Check that every variant of collections as all its files
     for (CollectionConfiguration collection in _configuration.collections) {
       filesToCheck.addAll(collection
-          .getFilesList(sharedDirectory.path, collectionsDirectory.path)
+          .getFilesList(sharedDirectory.path, collectionsDirectory.path,
+              _configuration.version)
           .values);
     }
 

--- a/lib/model/collection_configuration.dart
+++ b/lib/model/collection_configuration.dart
@@ -40,7 +40,7 @@ class CollectionConfiguration {
   /// The key is the destination path of the file while the value is the
   /// source path of the file.
   Map<String, String> getFilesList(
-      String sharedAssetsPath, String collectionsPath) {
+      String sharedAssetsPath, String collectionsPath, String version) {
     final Map<String, String> files = {};
 
     for (String currentOs in os) {
@@ -51,7 +51,7 @@ class CollectionConfiguration {
 
           // Add collection file
           files.putIfAbsent(
-              "$baseOutputPath/$name.json",
+              "$baseOutputPath/${name}_${language}_v$version.json",
               () =>
                   "$collectionsPath/$name/$currentOs/$camera/${name}_$language.json");
 

--- a/lib/model/collection_configuration.dart
+++ b/lib/model/collection_configuration.dart
@@ -51,7 +51,7 @@ class CollectionConfiguration {
 
           // Add collection file
           files.putIfAbsent(
-              "$baseOutputPath/${name}_${language}_v$version.json",
+              "$baseOutputPath/${name}_${camera}_${language}_v$version.json",
               () =>
                   "$collectionsPath/$name/$currentOs/$camera/${name}_$language.json");
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: obs_collections_generator
 description: A sample command-line application.
-version: 1.1.1
+version: 1.2.0
 
 environment:
   sdk: '>=2.16.0 <3.0.0'


### PR DESCRIPTION
Currently, the collection file is named following this pattern: `<collection_name>.json` but OBS get all the collections files at the same place so we can't use a folder name to know the language, camera and version of the collection. 

This change will name the collection file following this pattern: `<collection_name>_<camera_name>_<language_code>_v<version>.json`